### PR TITLE
Disable FC mod when DLC only is enabled

### DIFF
--- a/worlds/outer_wilds/__init__.py
+++ b/worlds/outer_wilds/__init__.py
@@ -58,6 +58,7 @@ class OuterWildsWorld(World):
             self.options.enable_hn1_mod = EnableHearthsNeighborMod(0)
             self.options.enable_hn2_mod = EnableHearthsNeighbor2MagistariumMod(0)
             self.options.enable_outsider_mod = EnableTheOutsiderMod(0)
+            self.options.enable_fc_mod = EnableForgottenCastawaysMod(0)
 
         if self.options.spawn == Spawn.option_random_non_vanilla:
             max_spawn = Spawn.option_stranger if self.options.enable_eote_dlc else Spawn.option_giants_deep

--- a/worlds/outer_wilds/test/test_eote.py
+++ b/worlds/outer_wilds/test/test_eote.py
@@ -194,6 +194,7 @@ class TestDLCOnlyWithStoryMods(OuterWildsTestBase):
         "enable_ac_mod": 1,
         "enable_hn2_mod": 1,
         "enable_fq_mod": 1,
+        "enable_fc_mod": 1
     }
 
     def test_default(self):


### PR DESCRIPTION
## What is this fixing or adding?
Disables the FC mod when DLC only is enabled

## How was this tested?
1000 fuzzer runs, zero failures

## If this makes graphical changes, please attach screenshots.
N/A