### PR TITLE
Fix UT crashing on old seeds

### DIFF
--- a/worlds/outer_wilds/__init__.py
+++ b/worlds/outer_wilds/__init__.py
@@ -94,14 +94,14 @@ class OuterWildsWorld(World):
                     self.options.logsanity.value = slot_data["logsanity"]
                     self.options.enable_eote_dlc.value = slot_data["enable_eote_dlc"]
                     self.options.dlc_only.value = slot_data["dlc_only"]
-                    self.options.enable_hn1_mod.value = slot_data["enable_hn1_mod"]
-                    self.options.enable_hn2_mod.value = slot_data["enable_hn2_mod"]
-                    self.options.enable_outsider_mod.value = slot_data["enable_outsider_mod"]
-                    self.options.enable_ac_mod.value = slot_data["enable_ac_mod"]
-                    self.options.enable_fq_mod.value = slot_data["enable_fq_mod"]
-                    self.options.enable_fc_mod.value = slot_data["enable_fc_mod"]
-                    self.options.enable_eh_mod.value = slot_data["enable_eh_mod"]
-                    self.options.split_translator.value = slot_data["split_translator"]
+                    self.options.enable_hn1_mod.value = slot_data.get("enable_hn1_mod", False)
+                    self.options.enable_hn2_mod.value = slot_data.get("enable_hn2_mod", False)
+                    self.options.enable_outsider_mod.value = slot_data.get("enable_outsider_mod", False)
+                    self.options.enable_ac_mod.value = slot_data.get("enable_ac_mod", False)
+                    self.options.enable_fq_mod.value = slot_data.get("enable_fq_mod", False)
+                    self.options.enable_fc_mod.value = slot_data.get("enable_fc_mod", False)
+                    self.options.enable_eh_mod.value = slot_data.get("enable_eh_mod", False)
+                    self.options.split_translator.value = slot_data.get("split_translator", False)
             return
 
         # generate game-specific randomizations separate from AP items/locations


### PR DESCRIPTION
Prevents a situation where seed was generated on old version of apworld and UT tries to read nonexistent slot data.